### PR TITLE
Apply fix: Automated fixing issue: Define and throw a dedicated exception instead of using a generic one.

### DIFF
--- a/src/main/java/com/org/javadoc/ai/generator/config/GitHubConfig.java
+++ b/src/main/java/com/org/javadoc/ai/generator/config/GitHubConfig.java
@@ -14,18 +14,27 @@ public class GitHubConfig {
 
     @Value("${github.token}")
     private String githubToken;
+
     @Value("${github.repo}")
-    private  String repository;
+    private String repository;
+
     @Value("${github.default.branch}")
-    private  String defaultBranch;
+    private String defaultBranch;
 
     @Bean
     public GitHub gitHub() {
         try {
             return GitHub.connectUsingOAuth(githubToken);
         } catch (Exception e) {
-            throw new RuntimeException("Error connecting to GitHub: " + e.getMessage());
+            // Create a dedicated exception class for GitHub connection errors.
+            throw new GitHubConnectionException("Error connecting to GitHub.", e);
         }
     }
+}
 
+// Dedicated exception class for GitHub connection errors.
+class GitHubConnectionException extends RuntimeException {
+    public GitHubConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
This PR applies the following fix:

Automated fixing issue: Define and throw a dedicated exception instead of using a generic one.